### PR TITLE
Enable autonegotiation

### DIFF
--- a/group_6_cumulus_3.0/etc.network.interfaces
+++ b/group_6_cumulus_3.0/etc.network.interfaces
@@ -11,10 +11,19 @@ iface eth0 inet dhcp
  num_ports = 54
 %>
 
+auto swp1
+iface swp1
+  link-autoneg on
+
+auto swp2
+iface swp2
+  link-autoneg on
+
 %for port in range(3, num_ports + 1):
 
 auto swp${port}
 iface swp${port}
+  link-autoneg on
  %if port % 2:
   bridge-access ${vlanid}
  %else:


### PR DESCRIPTION
The "for" loop does not include swp1 and swp2. So to enable autonegotiation on all ports, swp1 and swp2 must be included individually.